### PR TITLE
EXIF-package and additional functionality for images (time correction)

### DIFF
--- a/data/pyrenamer.glade
+++ b/data/pyrenamer.glade
@@ -1281,7 +1281,7 @@ ____ to _
                   <widget class="GtkTable" id="images_table">
                     <property name="visible">True</property>
                     <property name="border_width">12</property>
-                    <property name="n_rows">4</property>
+                    <property name="n_rows">5</property>
                     <property name="n_columns">4</property>
                     <property name="column_spacing">6</property>
                     <property name="row_spacing">6</property>
@@ -1478,8 +1478,8 @@ Random number replacements:
                       </widget>
                       <packing>
                         <property name="right_attach">4</property>
-                        <property name="top_attach">3</property>
-                        <property name="bottom_attach">4</property>
+                        <property name="top_attach">4</property>
+                        <property name="bottom_attach">5</property>
                         <property name="x_options">GTK_FILL</property>
                         <property name="y_options"></property>
                       </packing>
@@ -1524,6 +1524,40 @@ Random number replacements:
                         <property name="top_attach">1</property>
                         <property name="bottom_attach">2</property>
                         <property name="x_options">GTK_FILL</property>
+                        <property name="y_options"></property>
+                      </packing>
+                    </child>
+                    <child>
+                      <widget class="GtkLabel" id="label36">
+                        <property name="visible">True</property>
+                        <property name="xalign">0</property>
+                        <property name="xpad">12</property>
+			<property name="label" translatable="yes">Image time correction in seconds</property>
+                        <property name="use_markup">True</property>
+                      </widget>
+                      <packing>
+                        <property name="top_attach">3</property>
+                        <property name="bottom_attach">4</property>
+                        <property name="x_options">GTK_FILL</property>
+                        <property name="y_options"></property>
+                      </packing>
+                    </child>
+                    <child>
+                      <widget class="GtkEntry" id="images_correction">
+                         <property name="visible">True</property>
+                         <property name="can_focus">True</property>
+                         <property name="tooltip" translatable="yes">0		no correction
+10		increase by 10 seconds
+120		increase by 2 minutes (= 120 seconds)
+-20		decreade by 20 seconds</property>
+                         <property name="text" translatable="yes">0</property>
+                         <signal name="changed" handler="on_images_correction_changed"/>
+                      </widget>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">2</property>
+                        <property name="top_attach">3</property>
+                        <property name="bottom_attach">4</property>
                         <property name="y_options"></property>
                       </packing>
                     </child>

--- a/src/pyrenamer.py
+++ b/src/pyrenamer.py
@@ -170,6 +170,7 @@ class pyRenamer:
         self.images_renamed_pattern = self.glade_tree.get_widget("images_renamed_pattern")
         self.images_original_pattern_combo = self.glade_tree.get_widget("images_original_pattern_combo")
         self.images_renamed_pattern_combo = self.glade_tree.get_widget("images_renamed_pattern_combo")
+        self.images_correction = self.glade_tree.get_widget("images_correction")
 
         self.music_original_pattern = self.glade_tree.get_widget("music_original_pattern")
         self.music_renamed_pattern = self.glade_tree.get_widget("music_renamed_pattern")
@@ -276,6 +277,7 @@ class pyRenamer:
                     "on_images_dest_edit_clicked": self.on_images_dest_edit_clicked,
                     "on_images_original_pattern_combo_changed": self.on_images_original_pattern_combo_changed,
                     "on_images_renamed_pattern_combo_changed": self.on_images_renamed_pattern_combo_changed,
+                    "on_images_correction_changed": self.on_images_correction_changed,
 
                     "on_music_original_pattern_changed": self.on_music_original_pattern_changed,
                     "on_music_renamed_pattern_changed": self.on_music_renamed_pattern_changed,
@@ -536,8 +538,9 @@ class pyRenamer:
             # Replace images using patterns
             pattern_ini = self.images_original_pattern.get_text()
             pattern_end = self.images_renamed_pattern.get_text()
+            correction = self.images_correction.get_text()
             newname, newpath = renamerfilefuncs.rename_using_patterns(newname, newpath, pattern_ini, pattern_end, self.count)
-            newname, newpath = renamerfilefuncs.replace_images(name, path, newname, newpath)
+            newname, newpath = renamerfilefuncs.replace_images(name, path, newname, newpath, correction)
 
         elif self.notebook.get_current_page() == 5 and (pyrenamerglob.have_hachoir or pyrenamerglob.have_eyed3):
             # Replace music using patterns
@@ -924,6 +927,13 @@ class pyRenamer:
 
 
     def on_images_renamed_pattern_changed(self, widget):
+        """ Disable Rename button (user has to click on Preview again) """
+        self.rename_button.set_sensitive(False)
+        self.menu_rename.set_sensitive(False)
+        if self.autopreview:
+            self.on_preview_button_clicked(None)
+
+    def on_images_correction_changed(self, widget):
         """ Disable Rename button (user has to click on Preview again) """
         self.rename_button.set_sensitive(False)
         self.menu_rename.set_sensitive(False)

--- a/src/pyrenamer_filefuncs.py
+++ b/src/pyrenamer_filefuncs.py
@@ -25,7 +25,7 @@ import dircache
 import glob
 import re
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 import random
 import unicodedata
 
@@ -304,28 +304,28 @@ def rename_using_patterns(name, path, pattern_ini, pattern_end, count):
     newname = newname.replace('{dir}', dir)
 
     # Some date replacements
-    newname = newname.replace('{date}', time.strftime("%d%b%Y", time.localtime()))
-    newname = newname.replace('{year}', time.strftime("%Y", time.localtime()))
-    newname = newname.replace('{month}', time.strftime("%m", time.localtime()))
-    newname = newname.replace('{monthname}', time.strftime("%B", time.localtime()))
-    newname = newname.replace('{monthsimp}', time.strftime("%b", time.localtime()))
-    newname = newname.replace('{day}', time.strftime("%d", time.localtime()))
-    newname = newname.replace('{dayname}', time.strftime("%A", time.localtime()))
-    newname = newname.replace('{daysimp}', time.strftime("%a", time.localtime()))
+    newname = newname.replace('{date}', datetime.strftime(datetime.now(), "%d%b%Y"))
+    newname = newname.replace('{year}', datetime.strftime(datetime.now(), "%Y"))
+    newname = newname.replace('{month}', datetime.strftime(datetime.now(), "%m"))
+    newname = newname.replace('{monthname}', datetime.strftime(datetime.now(), "%B"))
+    newname = newname.replace('{monthsimp}', datetime.strftime(datetime.now(), "%b"))
+    newname = newname.replace('{day}', datetime.strftime(datetime.now(), "%d"))
+    newname = newname.replace('{dayname}', datetime.strftime(datetime.now(), "%A"))
+    newname = newname.replace('{daysimp}', datetime.strftime(datetime.now(), "%a"))
 
     print "This routine is running!"
 
     # Some pattern matches for creation and modification date
     createdate, modifydate = get_filestat_data(get_new_path(name, path))
     if createdate is not None:
-        newname = newname.replace('{createdate}', time.strftime("%d%b%Y", createdate))
-        newname = newname.replace('{createyear}', time.strftime("%Y", createdate))
-        newname = newname.replace('{createmonth}', time.strftime("%m", createdate))
-        newname = newname.replace('{createmonthname}', time.strftime("%B", createdate))
-        newname = newname.replace('{createmonthsimp}', time.strftime("%b", createdate))
-        newname = newname.replace('{createday}', time.strftime("%d", createdate))
-        newname = newname.replace('{createdayname}', time.strftime("%A", createdate))
-        newname = newname.replace('{createdaysimp}', time.strftime("%a", createdate))
+        newname = newname.replace('{createdate}', datetime.strftime(createdate, "%d%b%Y"))
+        newname = newname.replace('{createyear}', datetime.strftime(createdate, "%Y"))
+        newname = newname.replace('{createmonth}', datetime.strftime(createdate, "%m"))
+        newname = newname.replace('{createmonthname}', datetime.strftime(createdate, "%B"))
+        newname = newname.replace('{createmonthsimp}', datetime.strftime(createdate, "%b"))
+        newname = newname.replace('{createday}', datetime.strftime(createdate, "%d"))
+        newname = newname.replace('{createdayname}', datetime.strftime(createdate, "%A"))
+        newname = newname.replace('{createdaysimp}', datetime.strftime(createdate, "%a"))
     else:
         newname = newname.replace('{createdate}', '')
         newname = newname.replace('{createyear}', '')
@@ -337,14 +337,14 @@ def rename_using_patterns(name, path, pattern_ini, pattern_end, count):
         newname = newname.replace('{createdaysimp}', '')
 
     if modifydate is not None:
-        newname = newname.replace('{modifydate}', time.strftime("%d%b%Y", modifydate))
-        newname = newname.replace('{modifyyear}', time.strftime("%Y", modifydate))
-        newname = newname.replace('{modifymonth}', time.strftime("%m", modifydate))
-        newname = newname.replace('{modifymonthname}', time.strftime("%B", modifydate))
-        newname = newname.replace('{modifymonthsimp}', time.strftime("%b", modifydate))
-        newname = newname.replace('{modifyday}', time.strftime("%d", modifydate))
-        newname = newname.replace('{modifydayname}', time.strftime("%A", modifydate))
-        newname = newname.replace('{modifydaysimp}', time.strftime("%a", modifydate))
+        newname = newname.replace('{modifydate}', datetime.strftime(modifydate, "%d%b%Y"))
+        newname = newname.replace('{modifyyear}', datetime.strftime(modifydate, "%Y"))
+        newname = newname.replace('{modifymonth}', datetime.strftime(modifydate, "%m"))
+        newname = newname.replace('{modifymonthname}', datetime.strftime(modifydate, "%B"))
+        newname = newname.replace('{modifymonthsimp}', datetime.strftime(modifydate, "%b"))
+        newname = newname.replace('{modifyday}', datetime.strftime(modifydate, "%d"))
+        newname = newname.replace('{modifydayname}', datetime.strftime(modifydate, "%A"))
+        newname = newname.replace('{modifydaysimp}', datetime.strftime(modifydate, "%a"))
     else:
         newname = newname.replace('{modifydate}', '')
         newname = newname.replace('{modifyyear}', '')


### PR DESCRIPTION
Hi there,

I just added two new features to pyrenamer:
- instead of using the bundled EXIF.py use the standard python package exifread (seems to be actively developed)
- added a "time correction" field allowing to change the EXIF timestamp by a given amount of seconds before applying to the filename. 

Background of the second change is that when using more than one camera, usually the internal time settings are not synchronized and it is therefore useful to manually correct timestamps and renaming files before merging pictures from more than one camera. This can be done easily by the provided functionality.